### PR TITLE
Fix compaction of non-presorted tuples

### DIFF
--- a/src/encryption/enc_tuple.c
+++ b/src/encryption/enc_tuple.c
@@ -48,7 +48,7 @@ void PGTdeCryptTupInternal(Oid tableOid, BlockNumber bn, unsigned long offsetInP
 	for(unsigned i = 0; i < to - from; ++i) {
 		const char v = ((char*)(t_data))[i + from];
 		char realKey = encKey[aesBlockOffset + i];
-#if ENCRYPTION_DEBUG
+#if ENCRYPTION_DEBUG > 1
 	    fprintf(stderr, " >> 0x%02hhX 0x%02hhX\n", v & 0xFF, (v ^ realKey) & 0xFF);
 #endif
 		out[i + from] = v ^ realKey;

--- a/src/test/non_sorted_off_compact.sql
+++ b/src/test/non_sorted_off_compact.sql
@@ -1,0 +1,48 @@
+-- A test case for https://github.com/Percona-Lab/postgres-tde-ext/pull/21
+-- 
+DROP TABLE IF EXISTS sbtest1;
+CREATE TABLE sbtest1(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING pg_tde;
+
+INSERT INTO sbtest1(k) VALUES
+(1),
+(2),
+(3),
+(4),
+(5),
+(6),
+(7),
+(8),
+(9),
+(10);
+DELETE FROM sbtest1 WHERE id IN (4,5,6);
+
+VACUUM sbtest1;
+
+INSERT INTO sbtest1(k) VALUES
+(11),
+(12),
+(13);
+
+-- Line pointers (lp) point to non-sorted offsets (lp_off):
+-- CREATE EXTENSION pageinspect;
+-- SELECT lp, lp_off, t_ctid FROM heap_page_items(get_raw_page('sbtest1', 0));
+--  lp | lp_off | t_ctid
+-- ----+--------+--------
+--   1 |   8160 | (0,1)
+--   2 |   8128 | (0,2)
+--   3 |   8096 | (0,3)
+--   4 |   7936 | (0,4)
+--   5 |   7904 | (0,5)
+--   6 |   7872 | (0,6)
+--   7 |   8064 | (0,7)
+--   8 |   8032 | (0,8)
+--   9 |   8000 | (0,9)
+--  10 |   7968 | (0,10)
+
+---- Trigger comapction
+delete from sbtest1 where id in (2);
+VACUUM sbtest1;


### PR DESCRIPTION
That covers the case when line pointers (lp) point to unsorted offsets (tuples):
```
SELECT lp, lp_off, t_ctid FROM heap_page_items(get_raw_page('sbtest1', 0));
 lp | lp_off | t_ctid
----+--------+--------
  1 |   7960 | (0,1)
  2 |   7264 | (0,2)
  3 |   7032 | (0,3)
  4 |   6800 | (0,4)
  5 |   7728 | (0,5)
  6 |      0 |
  7 |   7496 | (0,7)
(7 rows)
```

This condition can be achieved by deleting some tuples and running VACUUM

Also, the encoded bytes printing is hidden behind higher ENCRYPTION_DEBUG. It floods log a lot otherwise.