### PR TITLE
Fix VACUUM FULL

### DIFF
--- a/src/access/pg_tde_rewrite.c
+++ b/src/access/pg_tde_rewrite.c
@@ -711,7 +711,7 @@ raw_pg_tde_insert(RewriteState state, HeapTuple tup)
 	}
 
 	/* And now we can insert the tuple into the page */
-	newoff = TDE_PageAddItem(heaptup->t_tableOid, BufferGetBlockNumber(state->rs_buffer), page, (Item) heaptup->t_data, heaptup->t_len,
+	newoff = TDE_PageAddItem(heaptup->t_tableOid, state->rs_blockno, page, (Item) heaptup->t_data, heaptup->t_len,
 						 InvalidOffsetNumber, false, true);
 	if (newoff == InvalidOffsetNumber)
 		elog(ERROR, "failed to add tuple");


### PR DESCRIPTION
VACUUM FULL rewrites tuple in order to possibly compact them after columns drops etc. And when it calls `raw_pg_tde_insert` buffer of the `RewriteState` is not valid as the Page is being built. So we have to use the block num from `RewriteState`.