### PR TITLE
Keyring config and datafile minor UX improvements

### DIFF
--- a/src/keyring/keyring_config.c
+++ b/src/keyring/keyring_config.c
@@ -24,10 +24,9 @@ static bool keyringCheckConfigFile(char **newval, void **extra, GucSource source
 		return 0;
 	}
 
-	if(access(*newval, W_OK) != 0)
+	if(access(*newval, W_OK) == 0)
 	{
-		elog(WARNING, "The file referenced by pg_tde.keyringConfigFile is writable to the database process");
-		return 0;
+		elog(WARNING, "The file referenced by pg_tde.keyringConfigFile is writable for the database process");
 	}
 
 	return 1;

--- a/src/keyring/keyring_file.c
+++ b/src/keyring/keyring_file.c
@@ -42,9 +42,9 @@ int keyringFilePreloadCache(void)
 	{
 		fread(cache, keyringCacheMemorySize(), 1, f);
 		fclose(f);
-		elog(WARNING, "Keyring file %s found, existing keys are available, %u.", keyringFileDataFileName, cache->keyCount);
+		elog(INFO, "Keyring file '%s' found, existing keys are available, %u.", keyringFileDataFileName, cache->keyCount);
 	} else {
-		elog(WARNING, "Keyring file %s not found, not loading existing keys.", keyringFileDataFileName);
+		elog(WARNING, "Keyring file '%s' not found, not loading existing keys.", keyringFileDataFileName);
 	}
 
 	return 1;
@@ -52,11 +52,16 @@ int keyringFilePreloadCache(void)
 
 int keyringFileStoreKey(const keyInfo* ki)
 {
+	if (strlen(keyringFileDataFileName) == 0) {
+		elog(ERROR, "Keyring datafile is not set");
+		return false;
+	}
+
 	// First very basic prototype: we just dump the cache to disk
 	FILE* f = fopen(keyringFileDataFileName, "w");
 	if(f == NULL)
 	{
-		elog(ERROR, "Couldn't write keyring data: %s", keyringFileDataFileName);
+		elog(ERROR, "Couldn't write keyring data into '%s'", keyringFileDataFileName);
 		return false;
 	}
 


### PR DESCRIPTION
1. If tde config file is writable to DB it shouldn't prevent its loading.

2. If keyringCheckConfigFile() returns 0, config won't be loaded. Hence keyringAssignConfigFile() and all its checks will be omitted. And user gonna get a bit confusing error at the access of tde table:
```
PANIC:  Couldn't write keyring data:
```
So added check if keyringFileDataFileName is set. And the error now:
```
ERROR:  Keyring datafile is not set
```

3. Add quote marks around file names in log messages so it's easier to spot if the file name is empty.
`Keyring file  not found, not loading existing keys.`
vs
`Keyring file '' not found, not loading existing keys.`