### PR TITLE
Fix indexes comparison on UPDATE

### DIFF
--- a/src/access/pg_tdeam.c
+++ b/src/access/pg_tdeam.c
@@ -3095,6 +3095,9 @@ pg_tde_update(Relation relation, ItemPointer otid, HeapTuple newtup,
 	oldtup.t_data = (HeapTupleHeader) PageGetItem(page, lp);
 	oldtup.t_len = ItemIdGetLength(lp);
 	oldtup.t_self = *otid;
+	/* decrypt the old tuple */
+	RelKeysData *keys = GetRelationKeys(relation->rd_locator);
+	PGTdeDecryptTupData(BufferGetBlockNumber(buffer), page, &oldtup, keys);
 
 	/* the new tuple is ready, except for this: */
 	newtup->t_tableOid = RelationGetRelid(relation);
@@ -4011,7 +4014,6 @@ HeapDetermineColumnsInfo(Relation relation,
 		 */
 		value1 = pg_tde_getattr(oldtup, attrnum, tupdesc, &isnull1);
 		value2 = pg_tde_getattr(newtup, attrnum, tupdesc, &isnull2);
-
 		if (!pg_tde_attr_equals(tupdesc, attrnum, value1,
 							  value2, isnull1, isnull2))
 		{

--- a/src/encryption/enc_tuple.c
+++ b/src/encryption/enc_tuple.c
@@ -95,7 +95,7 @@ static void PGTdeDecryptTupInternal2(BlockNumber bn, Page page, HeapTuple tuple,
 	}
 }
 
-static void PGTdeDecryptTupData(BlockNumber bn, Page page, HeapTuple tuple, RelKeysData* keys) 
+void PGTdeDecryptTupData(BlockNumber bn, Page page, HeapTuple tuple, RelKeysData* keys) 
 {
 	PGTdeDecryptTupInternal2(bn, page, tuple, tuple->t_data->t_hoff, tuple->t_len, true, keys);
 }

--- a/src/include/encryption/enc_tuple.h
+++ b/src/include/encryption/enc_tuple.h
@@ -8,9 +8,11 @@
 #include "executor/tuptable.h"
 #include "access/pg_tde_tdemap.h"
 
+/* TODO: clean up external interface. Now are too much of similar functions */
 void PGTdeCryptTupInternal(Oid tableOid, BlockNumber bn, unsigned long offsetInPage, char* t_data, char* out, unsigned from, unsigned to, RelKeysData* keys);
 void PGTdeEncryptTupInternal(Oid tableOid, BlockNumber bn, char* page, char* t_data, char* out, unsigned from, unsigned to, RelKeysData* keys);
 void PGTdeDecryptTupInternal(Oid tableOid, BlockNumber bn, Page page, HeapTupleHeader t_data, char* out, unsigned from, unsigned to, RelKeysData* keys);
+void PGTdeDecryptTupData(BlockNumber bn, Page page, HeapTuple tuple, RelKeysData* keys);
 
 /* A wrapper to encrypt a tuple before adding it to the buffer */
 OffsetNumber

--- a/src/test/update_compare_indexes.sql
+++ b/src/test/update_compare_indexes.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS pvactst;
+CREATE TABLE pvactst (i INT, a INT[], p POINT) USING pg_tde;
+INSERT INTO pvactst SELECT i, array[1,2,3], point(i, i+1) FROM generate_series(1,1000) i;
+CREATE INDEX spgist_pvactst ON pvactst USING spgist (p);
+UPDATE pvactst SET i = i WHERE i < 1000;
+-- crash!


### PR DESCRIPTION
There is a check during the UPDATE for changed indexes. Sometimes it causes a crash since the new tuple is unencrypted and the old is encrypted.
Besides comparison didn't work properly. Which leads to taking a suboptimal code path. And probably computing wrong replica identity and freeing used tuple in some cases.