### PR TITLE
Create tde fork (key) file for toast relations

### DIFF
--- a/src/access/pg_tde_ddl.c
+++ b/src/access/pg_tde_ddl.c
@@ -41,6 +41,7 @@ static void
     if (rel != NULL)
     {
         if ((rel->rd_rel->relkind == RELKIND_RELATION ||
+            rel->rd_rel->relkind == RELKIND_TOASTVALUE ||
             rel->rd_rel->relkind == RELKIND_MATVIEW) &&
             (subId == 0) && is_pg_tde_rel(rel))
             {

--- a/src/access/pg_tdeam_handler.c
+++ b/src/access/pg_tdeam_handler.c
@@ -635,10 +635,11 @@ pg_tdeam_relation_set_new_filelocator(Relation rel,
 
 	smgrclose(srel);
 	if (rel->rd_rel->relkind == RELKIND_RELATION ||
-		rel->rd_rel->relkind == RELKIND_MATVIEW	)
+		rel->rd_rel->relkind == RELKIND_MATVIEW	||
+		rel->rd_rel->relkind == RELKIND_TOASTVALUE)
 	{
-		ereport(DEBUG2,
-		(errmsg("creating key file for relation %s", RelationGetRelationName(rel))));
+		ereport(DEBUG1,
+			(errmsg("creating key file for relation %s", RelationGetRelationName(rel))));
 		pg_tde_create_key_fork(newrlocator, rel);
 	}
 }


### PR DESCRIPTION
Toast tables are treated as a separate relations internally. So must have it's own key files