### PR TITLE
Load relation keys into cache before critical sections

### DIFF
--- a/src/access/pg_tde_prune.c
+++ b/src/access/pg_tde_prune.c
@@ -384,6 +384,14 @@ pg_tde_page_prune(Relation relation, Buffer buffer,
 	if (off_loc)
 		*off_loc = InvalidOffsetNumber;
 
+	/* 
+	 * Make sure relation keys in the cahce to avoid pallocs in
+	 * the critical section.
+	 * We need it here as there is `pgtde_compactify_tuples()` down in
+	 * the call stack wich reencrypt tuples.
+	*/
+	GetRelationKeys(relation->rd_locator);
+
 	/* Any error while applying the changes is critical */
 	START_CRIT_SECTION();
 

--- a/src/access/pg_tdeam.c
+++ b/src/access/pg_tdeam.c
@@ -1875,6 +1875,12 @@ pg_tde_insert(Relation relation, HeapTuple tup, CommandId cid,
 	 */
 	CheckForSerializableConflictIn(relation, NULL, InvalidBlockNumber);
 
+	/* 
+	 * Make sure relation keys in the cahce to avoid pallocs in
+	 * the critical section. 
+	*/
+	GetRelationKeys(relation->rd_locator);
+
 	/* NO EREPORT(ERROR) from here till changes are logged */
 	START_CRIT_SECTION();
 
@@ -2206,6 +2212,12 @@ pg_tde_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 
 		if (starting_with_empty_page && (options & HEAP_INSERT_FROZEN))
 			all_frozen_set = true;
+
+		/* 
+		 * Make sure relation keys in the cahce to avoid pallocs in
+		 * the critical section. 
+		*/
+		GetRelationKeys(relation->rd_locator);
 
 		/* NO EREPORT(ERROR) from here till changes are logged */
 		START_CRIT_SECTION();
@@ -3735,6 +3747,12 @@ l2:
 										   bms_overlap(modified_attrs, id_attrs) ||
 										   id_has_external,
 										   &old_key_copied);
+
+	/* 
+	 * Make sure relation keys in the cahce to avoid pallocs in
+	 * the critical section. 
+	*/
+	GetRelationKeys(relation->rd_locator);
 
 	/* NO EREPORT(ERROR) from here till changes are logged */
 	START_CRIT_SECTION();


### PR DESCRIPTION
Internal keys are being fetched on each encrypt/decrypt op. Which causes allocations in PG's memory context when keys are not in the cache. Such allocations shouldn't happen while in a critical section. So we make sure the keys are in the cache before entering the critical section should any encrypt/decrypt ops be there.

Fixes https://github.com/Percona-Lab/postgres-tde-ext/issues/33