### PR TITLE
Basic is encrypted check function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXTENSION = pg_tde
 DATA = pg_tde--1.0.sql
 
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/postgres-tde-ext/postgres-tde-ext.conf --inputdir=regression
-REGRESS = non_sorted_off_compact update_compare_indexes
+REGRESS = non_sorted_off_compact update_compare_indexes pgtde_is_encrypted
 
 OBJS = src/encryption/enc_tuple.o \
 src/encryption/enc_aes.o \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ You can also build a docker image manually with:
 docker build . -f ./docker/Dockerfile -t your-image-name
 ```
 
+## Helper functions
+
+The extension provides the following helper functions:
+
+### pgtde_is_encrypted(tablename)
+
+Returns `t` if the table is encrypted (uses the pg_tde access method), or `f` otherwise.
+
 ## Base commit
 
 This is based on the heap code as of the following commit:

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,7 @@ tests += {
     'sql': [
       'non_sorted_off_compact',
       'update_compare_indexes',
+      'pgtde_is_encrypted',
     ],
     'regress_args': ['--temp-config', files('postgres-tde-ext.conf')],
     'runningcheck': false,

--- a/pg_tde--1.0.sql
+++ b/pg_tde--1.0.sql
@@ -8,6 +8,11 @@ RETURNS table_am_handler
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+CREATE FUNCTION pgtde_is_encrypted(table_name VARCHAR)
+RETURNS boolean
+AS $$ SELECT amname = 'pg_tde' FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = table_name $$
+LANGUAGE SQL;
+
 -- Access method
 CREATE ACCESS METHOD pg_tde TYPE TABLE HANDLER pg_tdeam_handler;
 COMMENT ON ACCESS METHOD pg_tde IS 'pg_tde table access method';

--- a/regression/expected/pgtde_is_encrypted.out
+++ b/regression/expected/pgtde_is_encrypted.out
@@ -1,0 +1,38 @@
+CREATE EXTENSION pg_tde;
+CREATE TABLE test_enc(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING pg_tde;
+CREATE TABLE test_norm(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING heap;
+SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_enc';
+ amname 
+--------
+ pg_tde
+(1 row)
+
+SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_norm';
+ amname 
+--------
+ heap
+(1 row)
+
+SELECT pgtde_is_encrypted('test_enc');
+ pgtde_is_encrypted 
+--------------------
+ t
+(1 row)
+
+SELECT pgtde_is_encrypted('test_norm');
+ pgtde_is_encrypted 
+--------------------
+ f
+(1 row)
+
+DROP TABLE test_enc;
+DROP TABLE test_norm;
+DROP EXTENSION pg_tde;

--- a/regression/sql/pgtde_is_encrypted.sql
+++ b/regression/sql/pgtde_is_encrypted.sql
@@ -1,0 +1,24 @@
+CREATE EXTENSION pg_tde;
+
+CREATE TABLE test_enc(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING pg_tde;
+
+CREATE TABLE test_norm(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) USING heap;
+
+SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_enc';
+SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_norm';
+
+SELECT pgtde_is_encrypted('test_enc');
+SELECT pgtde_is_encrypted('test_norm');
+
+DROP TABLE test_enc;
+DROP TABLE test_norm;
+
+DROP EXTENSION pg_tde;


### PR DESCRIPTION
This commit adds a new SQL function, `pgtde_is_encrypted(tablename)` which returns a boolean value: true if the table is encrypted with pg_tde, false otherwise.

As the pg_tde access method only writes encrypted data, it just checks if the table uses the am.

Fixes #40 