### PR TITLE
Fix for: Issue-36 Toast values are not getting encrypt

### DIFF
--- a/src/access/pg_tdeam.c
+++ b/src/access/pg_tdeam.c
@@ -1168,7 +1168,7 @@ pg_tde_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableSlot 
 
 	pgstat_count_pg_tde_getnext(scan->rs_base.rs_rd);
 
-	PGTdeExecStoreBufferHeapTuple(sscan->rs_rd->rd_locator, &scan->rs_ctup, slot,
+	PGTdeExecStoreBufferHeapTuple(sscan->rs_rd, &scan->rs_ctup, slot,
 							 scan->rs_cbuf);
 	return true;
 }
@@ -1316,7 +1316,7 @@ pg_tde_getnextslot_tidrange(TableScanDesc sscan, ScanDirection direction,
 	 */
 	pgstat_count_pg_tde_getnext(scan->rs_base.rs_rd);
 
-	PGTdeExecStoreBufferHeapTuple(sscan->rs_rd->rd_locator, &scan->rs_ctup, slot, scan->rs_cbuf);
+	PGTdeExecStoreBufferHeapTuple(sscan->rs_rd, &scan->rs_ctup, slot, scan->rs_cbuf);
 	return true;
 }
 

--- a/src/access/pg_tdeam_handler.c
+++ b/src/access/pg_tdeam_handler.c
@@ -169,7 +169,7 @@ pg_tdeam_index_fetch_tuple(struct IndexFetchTableData *scan,
 		*call_again = !IsMVCCSnapshot(snapshot);
 
 		slot->tts_tableOid = RelationGetRelid(scan->rel);
-		PGTdeExecStoreBufferHeapTuple(scan->rel->rd_locator, &bslot->base.tupdata, slot, hscan->xs_cbuf);
+		PGTdeExecStoreBufferHeapTuple(scan->rel, &bslot->base.tupdata, slot, hscan->xs_cbuf);
 	}
 	else
 	{
@@ -201,7 +201,7 @@ pg_tdeam_fetch_row_version(Relation relation,
 	if (pg_tde_fetch(relation, snapshot, &bslot->base.tupdata, &buffer, false))
 	{
 		/* store in slot, transferring existing pin */
-		PGTdeExecStorePinnedBufferHeapTuple(relation->rd_locator, &bslot->base.tupdata, slot, buffer);
+		PGTdeExecStorePinnedBufferHeapTuple(relation, &bslot->base.tupdata, slot, buffer);
 		slot->tts_tableOid = RelationGetRelid(relation);
 
 		return true;
@@ -575,7 +575,7 @@ tuple_lock_retry:
 	tuple->t_tableOid = slot->tts_tableOid;
 
 	/* store in slot, transferring existing pin */
-	PGTdeExecStorePinnedBufferHeapTuple(relation->rd_locator, tuple, slot, buffer);
+	PGTdeExecStorePinnedBufferHeapTuple(relation, tuple, slot, buffer);
 
 	return result;
 }
@@ -1166,7 +1166,7 @@ pg_tdeam_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
 
 		if (sample_it)
 		{
-			PGTdeExecStoreBufferHeapTuple(scan->rs_rd->rd_locator, targtuple, slot, hscan->rs_cbuf);
+			PGTdeExecStoreBufferHeapTuple(scan->rs_rd, targtuple, slot, hscan->rs_cbuf);
 			hscan->rs_cindex++;
 
 			/* note that we leave the buffer locked here! */
@@ -1646,7 +1646,7 @@ pg_tdeam_index_build_range_scan(Relation heapRelation,
 		MemoryContextReset(econtext->ecxt_per_tuple_memory);
 
 		/* Set up for predicate or expression evaluation */
-		PGTdeExecStoreBufferHeapTuple(heapRelation->rd_locator, heapTuple, slot, hscan->rs_cbuf);
+		PGTdeExecStoreBufferHeapTuple(heapRelation, heapTuple, slot, hscan->rs_cbuf);
 
 		/*
 		 * In a partial index, discard tuples that don't satisfy the
@@ -2280,7 +2280,7 @@ pg_tdeam_scan_bitmap_next_tuple(TableScanDesc scan,
 	 * Set up the result slot to point to this tuple.  Note that the slot
 	 * acquires a pin on the buffer.
 	 */
-	PGTdeExecStoreBufferHeapTuple(scan->rs_rd->rd_locator, &hscan->rs_ctup,
+	PGTdeExecStoreBufferHeapTuple(scan->rs_rd, &hscan->rs_ctup,
 							 slot,
 							 hscan->rs_cbuf);
 
@@ -2434,7 +2434,7 @@ pg_tdeam_scan_sample_next_tuple(TableScanDesc scan, SampleScanState *scanstate,
 			if (!pagemode)
 				LockBuffer(hscan->rs_cbuf, BUFFER_LOCK_UNLOCK);
 
-			PGTdeExecStoreBufferHeapTuple(scan->rs_rd->rd_locator, tuple, slot, hscan->rs_cbuf);
+			PGTdeExecStoreBufferHeapTuple(scan->rs_rd, tuple, slot, hscan->rs_cbuf);
 
 			/* Count successfully-fetched tuples as heap fetches */
 			pgstat_count_pg_tde_getnext(scan->rs_rd);

--- a/src/access/pg_tdetoast.c
+++ b/src/access/pg_tdetoast.c
@@ -833,11 +833,6 @@ pg_tde_toast_tuple_externalize(ToastTupleContext *ttc, int attribute, int option
 		data_p = VARDATA_SHORT(dval);
 		data_size = VARSIZE_SHORT(dval) - VARHDRSZ_SHORT;
 	}
-	else if (VARATT_IS_COMPRESSED(dval))
-	{
-		data_p = VARDATA(dval);
-		data_size = VARSIZE(dval) - VARHDRSZ;
-	}
 	else
 	{
 		data_p = VARDATA(dval);

--- a/src/include/encryption/enc_tuple.h
+++ b/src/include/encryption/enc_tuple.h
@@ -23,7 +23,17 @@ PGTdePageAddItemExtended(RelFileLocator rel, Oid oid, BlockNumber bn, Page page,
 					int flags);
 
 /* Wrapper functions for reading decrypted tuple into a given slot */
-TupleTableSlot *
-PGTdeExecStoreBufferHeapTuple(RelFileLocator rel, HeapTuple tuple, TupleTableSlot *slot, Buffer buffer);
-TupleTableSlot *
-PGTdeExecStorePinnedBufferHeapTuple(RelFileLocator rel, HeapTuple tuple, TupleTableSlot *slot, Buffer buffer);
+extern TupleTableSlot *
+PGTdeExecStoreBufferHeapTuple(Relation rel, HeapTuple tuple, TupleTableSlot *slot, Buffer buffer);
+extern TupleTableSlot *
+PGTdeExecStorePinnedBufferHeapTuple(Relation rel, HeapTuple tuple, TupleTableSlot *slot, Buffer buffer);
+
+extern void
+pg_tde_crypt(uint64_t start_offset, const char* data, uint32 data_len, char* out, RelKeysData* keys, const char* context);
+
+#define PG_TDE_ENCRYPT_DATA(_start_offset, _data, _data_len, _out, _keys) \
+	pg_tde_crypt(_start_offset, _data, _data_len, _out, _keys, "ENCRYPT")
+
+#define PG_TDE_DECRYPT_DATA(_start_offset, _data, _data_len, _out, _keys) \
+	pg_tde_crypt(_start_offset, _data, _data_len, _out, _keys, "DECRYPT")
+


### PR DESCRIPTION
Toast values are inserted into toast relations directly by the core, so the trick is sending the encrypted data to the core before it gets externalized. Similarly, when creating the tuple with toasted value, decrypt the toated chunks before constructing the resulting tuple.