### PR TITLE
Fixing SSL warning after server restart

### DIFF
--- a/.github/workflows/postgresql-16-src-meson.yml
+++ b/.github/workflows/postgresql-16-src-meson.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           cp ../contrib/postgres-tde-ext/keyring.json /tmp/keyring.json
           meson test --suite setup -v
-          meson test --suite postgres-tde-ext -v
+          meson test --suite postgres-tde-ext -v --num-processes 1
         working-directory: src/build
 
       - name: Report on test fail

--- a/src/encryption/enc_aes.c
+++ b/src/encryption/enc_aes.c
@@ -65,6 +65,8 @@ static void AesRun2(EVP_CIPHER_CTX** ctxPtr, int enc, const unsigned char* key, 
 	{
 		*ctxPtr = EVP_CIPHER_CTX_new();
 		EVP_CIPHER_CTX_init(*ctxPtr);
+		
+		EVP_CIPHER_CTX_set_padding(*ctxPtr, 0);
 
 		if(EVP_CipherInit_ex(*ctxPtr, cipher2, NULL, key, iv, enc) == 0) {
 			fprintf(stderr, "ERROR: EVP_CipherInit_ex failed. OpenSSL error: %s\n", ERR_error_string(ERR_get_error(), NULL));
@@ -84,6 +86,7 @@ static void AesRun(int enc, const unsigned char* key, const unsigned char* iv, c
 	ctx = EVP_CIPHER_CTX_new();
 	EVP_CIPHER_CTX_init(ctx);
 
+	EVP_CIPHER_CTX_set_padding(ctx, 0);
 
 	if(EVP_CipherInit_ex(ctx, cipher, NULL, key, iv, enc) == 0) {
 		fprintf(stderr, "ERROR: EVP_CipherInit_ex failed. OpenSSL error: %s\n", ERR_error_string(ERR_get_error(), NULL));

--- a/src/include/keyring/keyring_api.h
+++ b/src/include/keyring/keyring_api.h
@@ -49,5 +49,6 @@ const keyInfo* keyringStoreKey(keyName name, keyData data);
 unsigned keyringCacheMemorySize(void);
 void keyringInitCache(void);
 const keyInfo* keyringCacheStoreKey(keyName name, keyData data);
+const char * tde_sprint_masterkey(const keyData *k);
 
 #endif // KEYRING_API_H

--- a/src/include/pg_tde_defines.h
+++ b/src/include/pg_tde_defines.h
@@ -19,9 +19,9 @@
  * ----------
 */
 
-#define ENCRYPTION_DEBUG 0
+#define ENCRYPTION_DEBUG 1
 #define KEYRING_DEBUG 1
-#define TDE_FORK_DEBUG 0
+#define TDE_FORK_DEBUG 1
 
 #define pg_tde_fill_tuple heap_fill_tuple
 #define pg_tde_form_tuple heap_form_tuple

--- a/t/001_basic.pl
+++ b/t/001_basic.pl
@@ -36,17 +36,32 @@ ok($rt_value == 3, "Failing query");
 
 
 # Restart the server
-$node->stop;
+PGTDE::append_to_file("-- server restart");
+$node->stop();
 
 # UPDATE postgresql.conf to include/load pg_tde library
-open my $conf, '>>', "$pgdata/postgresql.conf";
+open $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "pg_tde.keyringConfigFile = '/tmp/keyring.json'\n";
 close $conf;
 
-my $rt_value = $node->start;
+$rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING pg_tde;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5),(6);', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
@@ -57,7 +72,7 @@ $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params =>
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 # Stop the server
-$node->stop;
+$node->stop();
 
 # compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/t/expected/001_basic.out
+++ b/t/expected/001_basic.out
@@ -1,4 +1,13 @@
 CREATE EXTENSION pg_tde;
+-- server restart
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING pg_tde;
+INSERT INTO test_enc (k) VALUES (5),(6);
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+-- server restart
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
 DROP TABLE test_enc;
 DROP EXTENSION pg_tde;


### PR DESCRIPTION
This commit disables padding for the fork file encryption to fix the above warning, and also contains related test / logging improvements.

The meson test runner is also restricted to one process to workaround issues where multiple processes write the same keyring data file, resulting in randomly failing test executions.