### PR TITLE
Fix update duplication after crashfix

### DIFF
--- a/expected/trigger_on_view.out
+++ b/expected/trigger_on_view.out
@@ -157,8 +157,7 @@ CONTEXT:  PL/pgSQL function city_update() line 9 at RAISE
  city_id | city_name | population | country_name | continent 
 ---------+-----------+------------+--------------+-----------
        1 | Tokyo     |   13010279 | Japan        | Asia
-       1 | Tokyo     |   13010279 |              | 
-(2 rows)
+(1 row)
 
  UPDATE city_view SET country_name = 'UK' WHERE city_name = 'New York' RETURNING *;
  city_id | city_name | population | country_name | continent 
@@ -170,23 +169,20 @@ CONTEXT:  PL/pgSQL function city_update() line 9 at RAISE
  city_id | city_name | population | country_name |   continent   
 ---------+-----------+------------+--------------+---------------
   123456 | New York  |    8391881 | USA          | North America
-  123456 | New York  |    8391881 | USA          | North America
-(2 rows)
+(1 row)
 
  UPDATE city_view SET continent = 'EU' WHERE continent = 'Europe' RETURNING *;
  city_id | city_name  | population | country_name | continent 
 ---------+------------+------------+--------------+-----------
   234567 | Birmingham |    1016800 | UK           | Europe
-  123456 | New York   |            | UK           | Europe
-(2 rows)
+(1 row)
 
  UPDATE city_view v1 SET country_name = v2.country_name FROM city_view v2
      WHERE v2.city_name = 'Birmingham' AND v1.city_name = 'London' RETURNING *;
  city_id | city_name | population | country_name | continent | city_id | city_name  | population | country_name | continent 
 ---------+-----------+------------+--------------+-----------+---------+------------+------------+--------------+-----------
        2 | London    |    7556900 | UK           | Europe    |  234567 | Birmingham |    1016800 | UK           | Europe
-       2 | London    |    7556900 | UK           | Europe    |  234567 | Birmingham |    1016800 | UK           | Europe
-(2 rows)
+(1 row)
 
  
  -- DELETE .. RETURNING

--- a/src/access/pg_tdeam.c
+++ b/src/access/pg_tdeam.c
@@ -3012,6 +3012,7 @@ pg_tde_update(Relation relation, ItemPointer otid, HeapTuple newtup,
 	ItemId		lp;
 	HeapTupleData oldtup;
 	HeapTupleData oldtup2;
+	void*		oldtupptr;
 	HeapTuple	heaptup;
 	HeapTuple	old_key_tuple = NULL;
 	bool		old_key_copied = false;
@@ -3111,6 +3112,7 @@ pg_tde_update(Relation relation, ItemPointer otid, HeapTuple newtup,
 	 */
 	oldtup.t_tableOid = RelationGetRelid(relation);
 	oldtup.t_data = (HeapTupleHeader) PageGetItem(page, lp);
+	oldtupptr = oldtup.t_data;
 	oldtup.t_len = ItemIdGetLength(lp);
 	oldtup.t_self = *otid;
 	/* decrypt the old tuple */
@@ -3185,6 +3187,8 @@ pg_tde_update(Relation relation, ItemPointer otid, HeapTuple newtup,
 	 * with the new tuple's location, so there's great risk of confusion if we
 	 * use otid anymore.
 	 */
+
+	oldtup.t_data = oldtupptr;
 
 l2:
 	checked_lockers = false;

--- a/src/access/pg_tdeam.c
+++ b/src/access/pg_tdeam.c
@@ -3011,8 +3011,8 @@ pg_tde_update(Relation relation, ItemPointer otid, HeapTuple newtup,
 	Bitmapset  *modified_attrs;
 	ItemId		lp;
 	HeapTupleData oldtup;
-	HeapTupleData oldtup2;
-	void*		oldtupptr;
+	HeapTupleData oldtup_decrypted;
+	void*		oldtup_data;
 	HeapTuple	heaptup;
 	HeapTuple	old_key_tuple = NULL;
 	bool		old_key_copied = false;
@@ -3112,24 +3112,24 @@ pg_tde_update(Relation relation, ItemPointer otid, HeapTuple newtup,
 	 */
 	oldtup.t_tableOid = RelationGetRelid(relation);
 	oldtup.t_data = (HeapTupleHeader) PageGetItem(page, lp);
-	oldtupptr = oldtup.t_data;
+	oldtup_data = oldtup.t_data;
 	oldtup.t_len = ItemIdGetLength(lp);
 	oldtup.t_self = *otid;
 	/* decrypt the old tuple */
 	{
 		char* new_ptr = NULL;
 		new_ptr = MemoryContextAlloc(CurTransactionContext, oldtup.t_len);
-		memcpy(new_ptr, oldtup.t_data, oldtup.t_len);
+		memcpy(new_ptr, oldtup.t_data, oldtup.t_data->t_hoff);
 		// only neccessary field
-		oldtup2.t_data = (HeapTupleHeader)new_ptr;
+		oldtup_decrypted.t_data = (HeapTupleHeader)new_ptr;
 	}
-	PG_TDE_DECRYPT_TUPLE(BufferGetBlockNumber(buffer), page, &oldtup, &oldtup2,
+	PG_TDE_DECRYPT_TUPLE(BufferGetBlockNumber(buffer), page, &oldtup, &oldtup_decrypted,
 							GetRelationKeys(relation->rd_locator));
 
 	// change field in oldtup now.
 	// We can't do it before, as PG_TDE_DECRYPT_TUPLE uses t_data address in 
 	// calculations
-	oldtup.t_data = oldtup2.t_data;
+	oldtup.t_data = oldtup_decrypted.t_data;
 
 	/* the new tuple is ready, except for this: */
 	newtup->t_tableOid = RelationGetRelid(relation);
@@ -3188,7 +3188,7 @@ pg_tde_update(Relation relation, ItemPointer otid, HeapTuple newtup,
 	 * use otid anymore.
 	 */
 
-	oldtup.t_data = oldtupptr;
+	oldtup.t_data = oldtup_data;
 
 l2:
 	checked_lockers = false;


### PR DESCRIPTION
Issue: with the fix in #67, pgtde decrypts tuples during update into a new memory region, and changes the t_data pointer to this new region.

Because of this, later updates to tuple flags also happen in the new data, and the original persisted tuple flags are never updated.

Fix: after the update statement is done with the decrypted data, restore the t_data pointer to the original. This way, flag changes happen where they should.

Fixes #68