### PR TITLE
Correctly disable debug outputs by default

### DIFF
--- a/src/include/pg_tde_defines.h
+++ b/src/include/pg_tde_defines.h
@@ -19,9 +19,9 @@
  * ----------
 */
 
-#define ENCRYPTION_DEBUG 0
-#define KEYRING_DEBUG 0
-#define TDE_FORK_DEBUG 0
+//#define ENCRYPTION_DEBUG 1
+//#define KEYRING_DEBUG 1
+//#define TDE_FORK_DEBUG 1
 
 #define pg_tde_fill_tuple heap_fill_tuple
 #define pg_tde_form_tuple heap_form_tuple


### PR DESCRIPTION
As we are using #ifdef checks insted of #if, the zero defined debug settings enable debug output. This causes increased log sizes and decreased performance.