### PR TITLE
Use a custom prefix instead of a hardcoded serverid for keys

### DIFF
--- a/src/include/keyring/keyring_config.h
+++ b/src/include/keyring/keyring_config.h
@@ -7,6 +7,7 @@
 #include <json.h>
 
 extern char* keyringConfigFile;
+extern char* keyringKeyPrefix;
 
 void keyringRegisterVariables(void);
 

--- a/src/keyring/keyring_api.c
+++ b/src/keyring/keyring_api.c
@@ -1,6 +1,7 @@
 
 #include "keyring/keyring_api.h"
 #include "keyring/keyring_file.h"
+#include "keyring/keyring_config.h"
 
 #include "postgres.h"
 #include "access/xlog.h"
@@ -82,7 +83,13 @@ const keyInfo* keyringStoreKey(keyName name, keyData data)
 keyName keyringConstructKeyName(const char* internalName, unsigned version)
 {
 	keyName name;
-	snprintf(name.name, sizeof(name.name), "%s-%u-%lu", internalName, version, GetSystemIdentifier());
+	if(keyringKeyPrefix != NULL && strlen(keyringKeyPrefix) > 0)
+	{
+		snprintf(name.name, sizeof(name.name), "%s-%s-%u", keyringKeyPrefix, internalName, version);
+	} else 
+	{
+		snprintf(name.name, sizeof(name.name), "%s-%u", internalName, version);
+	}
 	return name;
 }
 

--- a/src/keyring/keyring_config.c
+++ b/src/keyring/keyring_config.c
@@ -10,6 +10,23 @@
 #include "utils/guc.h"
 
 char* keyringConfigFile = "";
+char* keyringKeyPrefix = "";
+
+static bool keyringCheckKeyPrefix(char **newval, void **extra, GucSource source)
+{
+	if(*newval == NULL || strlen(*newval) == 0)
+	{
+		return 1; // empty
+	}
+
+	if(strlen(*newval) > 32)
+	{
+		elog(ERROR, "The maximum length of pg_tde.keyringKeyPrefix is 32 characters.");
+		return 0;
+	}
+
+	return 1;
+}
 
 static bool keyringCheckConfigFile(char **newval, void **extra, GucSource source)
 {
@@ -45,6 +62,7 @@ static void keyringAssignConfigFile(const char *newval, void *extra)
 
 void keyringRegisterVariables(void)
 {
+
 	DefineCustomStringVariable("pg_tde.keyringConfigFile", /* name */
 							"Location of the configuration file for the keyring", /* short_desc */
 							NULL,	/* long_desc */
@@ -54,6 +72,18 @@ void keyringRegisterVariables(void)
 							0,	/* flags */
 							&keyringCheckConfigFile,	/* check_hook */
 							&keyringAssignConfigFile,	/* assign_hook */
+							NULL	/* show_hook */
+		);
+
+	DefineCustomStringVariable("pg_tde.keyringKeyPrefix", /* name */
+							"Location of the configuration file for the keyring", /* short_desc */
+							NULL,	/* long_desc */
+							&keyringKeyPrefix,	/* value address */
+							"",	/* boot value */
+							PGC_POSTMASTER, /* context */
+							0,	/* flags */
+							&keyringCheckKeyPrefix,	/* check_hook */
+							NULL,	/* assign_hook */
 							NULL	/* show_hook */
 		);
 }

--- a/t/001_basic.pl
+++ b/t/001_basic.pl
@@ -42,6 +42,7 @@ $node->stop();
 # UPDATE postgresql.conf to include/load pg_tde library
 open $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "pg_tde.keyringConfigFile = '/tmp/keyring.json'\n";
+print $conf "pg_tde.keyringKeyPrefix = 'this-is-a-prefix'\n";
 close $conf;
 
 $rt_value = $node->start();


### PR DESCRIPTION
With this change, key names no longer contain the hardcoded serverid, but instead use a user specifiable and optional prefix.

With default settings the prefix is empty, and we generate key names in the format of "<name>-<version>". With a non empty prefix set, the format changes to "<prefix>-<name>-<version>".

The test suite is also modified, so that the existing TAP test uses a custom prefix, and the SQL tests use an empty prefix, to test both cases.