### PR TITLE
Fixing docker issues after replication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This setup is intended for developmenet, and stores the keys unencrypted in the 
 1. To build `pg_tde` from source code, you require the following on Ubuntu/Debian:
 
 ```sh
-sudo apt install make gcc libjson-c-dev postgresql-server-dev-16
+sudo apt install make gcc libjson-c-dev postgresql-server-dev-16 libcurl4-openssl-dev
 ```
 
 2. Install or build postgresql 16 [(see reference commit below)](#base-commit)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,13 +7,15 @@ RUN apt-get update; \
     libssl-dev \
     gcc \
     postgresql-server-dev-16 \
-    make
+    make \
+    libcurl4-openssl-dev
 
 WORKDIR /opt/postgres-tde-ext
 
 COPY . .
 
-RUN make USE_PGXS=1 && \
+RUN ./configure && \
+    make USE_PGXS=1 && \
     make USE_PGXS=1 install
 RUN cp /usr/share/postgresql/postgresql.conf.sample /etc/postgresql/postgresql.conf; \
     echo "shared_preload_libraries = 'pg_tde'" >> /etc/postgresql/postgresql.conf; \

--- a/docker/pg-tde-streaming-repl.sh
+++ b/docker/pg-tde-streaming-repl.sh
@@ -6,14 +6,13 @@ PG_PRIMARY=${PG_PRIMARY:-"false"}
 PG_REPLICATION=${PG_REPLICATION:-"false"}
 REPL_PASS=${REPL_PASS:-"replpass"}
 
-if [ !PG_REPLICATION = "true "] ; then
-    exit 0
-fi
-
-if [ $PG_PRIMARY == "true" ] ; then
+if [ "$PG_REPLICATION" == "true" ] ; then
+  if [ "$PG_PRIMARY" == "true" ] ; then
     psql -c "CREATE ROLE repl WITH REPLICATION PASSWORD '${REPL_PASS}' LOGIN;"
     echo "host replication repl 0.0.0.0/0 trust" >> ${PGDATA}/pg_hba.conf
-else
+  else
     rm -rf  ${PGDATA}/*
     pg_basebackup -h pg-primary -p 5432 -U repl -D ${PGDATA} -Fp -Xs -R
+  fi
 fi
+


### PR DESCRIPTION
Issue: the pg-tde-streaming-repl script exited if it was executed without replication turned on. This exit command actually exited the docker instance instead of just the initialization script.

The curl binary was also missing from the docker image, required for vault support, and the extension failed to build.