### PR TITLE
Store proper name with version in fork file

### DIFF
--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -124,7 +124,7 @@ pg_tde_write_key_fork(const RelFileLocator *rlocator, InternalKey *key, const ch
 	 * the cache as well */
 	data = (RelKeysData *) MemoryContextAlloc(TopMemoryContext, SizeOfRelKeysData(1));
 
-	strcpy(data->master_key_name, master_key_info->name.name);
+	strncpy(data->master_key_name, master_key_info->name.name, MASTER_KEY_NAME_LEN);
 	data->internal_key[0] = *key;
 	data->internal_keys_len = 1;
 
@@ -218,7 +218,7 @@ pg_tde_get_keys_from_fork(const RelFileLocator *rlocator)
 		unsigned char iv[INTERNAL_KEY_LEN] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
 		keyName master_key_name;
-		strncpy(master_key_name.name, keys->master_key_name, 256);
+		strncpy(master_key_name.name, keys->master_key_name, MASTER_KEY_NAME_LEN);
 		master_key_info = keyringGetKey(master_key_name);
 		if(master_key_info == NULL)
 		{

--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -124,7 +124,7 @@ pg_tde_write_key_fork(const RelFileLocator *rlocator, InternalKey *key, const ch
 	 * the cache as well */
 	data = (RelKeysData *) MemoryContextAlloc(TopMemoryContext, SizeOfRelKeysData(1));
 
-	strcpy(data->master_key_name, MasterKeyName);
+	strcpy(data->master_key_name, master_key_info->name.name);
 	data->internal_key[0] = *key;
 	data->internal_keys_len = 1;
 
@@ -217,11 +217,9 @@ pg_tde_get_keys_from_fork(const RelFileLocator *rlocator)
 		// TODO: use proper iv stored in the file!
 		unsigned char iv[INTERNAL_KEY_LEN] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-		master_key_info = keyringGetLatestKey(keys->master_key_name);
-		if(master_key_info == NULL)
-		{
-			master_key_info = keyringGenerateKey(keys->master_key_name, INTERNAL_KEY_LEN);
-		}
+		keyName master_key_name;
+		strncpy(master_key_name.name, keys->master_key_name, 256);
+		master_key_info = keyringGetKey(master_key_name);
 		if(master_key_info == NULL)
 		{
 			ereport(ERROR,


### PR DESCRIPTION
Currently the fork file stores just the string "master-key", which is incorrect, as it does not contain the version information. To counteract this, at read time it loads the latest master key, but that can be different than the version which was used to encrypt it.

These getLatestKey calls also lead to postgres making many unneccessary calls to vault, making this bug partially responsible for #90.

The fix is simple, from now on we correctly write the entire string including the version number, and read the specified version at read time.

Fixes #94.