### PR TITLE
Fix json syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ sudo systemctl restart postgresql.service
 
 ```json
 {
-        'provider': 'file',
-        'datafile': '/tmp/pgkeyring',
+        "provider": "file",
+        "datafile": "/tmp/pgkeyring"
 }
 ```
 

--- a/documentation/docs/setup.md
+++ b/documentation/docs/setup.md
@@ -62,11 +62,11 @@ Create the keyring configuration file with the following contents:
 
      ```json
      {
-             'provider': 'vault-v2',
-             'token': 'ROOT_TOKEN',
-             'url': 'http://127.0.0.1:8200',
-             'mountPath': 'secret'
-             'caPath': '<path/to/caFile>'
+             "provider": "vault-v2",
+             "token": "ROOT_TOKEN",
+             "url": "http://127.0.0.1:8200",
+             "mountPath": "secret",
+             "caPath": "<path/to/caFile>"
      }
      ```
 
@@ -82,8 +82,8 @@ Create the keyring configuration file with the following contents:
 
      ```json
      {
-             'provider': 'file',
-             'datafile': '/tmp/pgkeyring',
+             "provider": "file",
+             "datafile": "/tmp/pgkeyring"
      }
      ```     
 

--- a/keyring-vault.json
+++ b/keyring-vault.json
@@ -1,6 +1,6 @@
 {
-        'provider': 'vault-v2',
-        'token': 'ROOT_TOKEN',
-        'url': 'http://127.0.0.1:8200',
-        'mountPath': 'secret'
+        "provider": "vault-v2",
+        "token": "ROOT_TOKEN",
+        "url": "http://127.0.0.1:8200",
+        "mountPath": "secret"
 }

--- a/keyring.json
+++ b/keyring.json
@@ -1,4 +1,4 @@
 {
-        'provider': 'file',
-        'datafile': '/tmp/pgkeyring',
+        "provider": "file",
+        "datafile": "/tmp/pgkeyring"
 }


### PR DESCRIPTION
JSON format requires double quotes and last element should not end with a comma
https://www.json.org/json-en.html

>A string is a sequence of zero or more Unicode characters, wrapped in double quotes, using backslash escapes.

