### PR TITLE
Add MacOS specific linker flags to meson tests build step for MacOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,11 +43,19 @@ pg_tde = shared_module('pg_tde',
 )
 contrib_targets += pg_tde
 
+ldflags = []
+if host_machine.system() == 'darwin'
+  # On MacOS Shared Libraries and Loadable Modules are different things,
+  # so we need to pass an extra flag to the linker.
+  ldflags += '-bundle'
+endif
+
 enc_test = executable('enc_test',
   files('src/encryption/enc_aes.c', 'src/encryption/test.c'),
   kwargs: mod_args,
   include_directories: incdir,
   c_args : '-DFRONTEND',
+  link_args: ldflags,
 )
 
 pg_tde_perf = executable('enc_perf_test',
@@ -55,6 +63,7 @@ pg_tde_perf = executable('enc_perf_test',
   kwargs: contrib_mod_args,
   include_directories: incdir,
   c_args : '-DFRONTEND',
+  link_args: ldflags,
 )
 
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ deps_update = {'dependencies': contrib_mod_args.get('dependencies') + [jsondep, 
 
 mod_args = contrib_mod_args + deps_update
 
+
 pg_tde = shared_module('pg_tde',
   pg_tde_sources,
   c_pch: pch_postgres_h,
@@ -44,7 +45,7 @@ pg_tde = shared_module('pg_tde',
 contrib_targets += pg_tde
 
 ldflags = []
-if host_machine.system() == 'darwin'
+if host_system == 'darwin'
   # On MacOS Shared Libraries and Loadable Modules are different things,
   # so we need to pass an extra flag to the linker.
   ldflags += '-bundle'

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,6 @@ deps_update = {'dependencies': contrib_mod_args.get('dependencies') + [jsondep, 
 
 mod_args = contrib_mod_args + deps_update
 
-
 pg_tde = shared_module('pg_tde',
   pg_tde_sources,
   c_pch: pch_postgres_h,


### PR DESCRIPTION
Fixes https://github.com/Percona-Lab/postgres-tde-ext/issues/25

Unlike linux on MacOS [shared library and loadable module(bundle)](https://www.oreilly.com/library/view/mac-os-x/0596003560/ch05s03.html) are different things. So linker was miss `-bundle` flag for testing executables build.

https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/LoadingCode/Concepts/AboutLoadableBundles.html