### PR TITLE
Updating the toasted column in encrypted table causes the crash (#82)

### DIFF
--- a/src/access/pg_tdeam.c
+++ b/src/access/pg_tdeam.c
@@ -3634,7 +3634,7 @@ l2:
 		if (need_toast)
 		{
 			/* Note we always use WAL and FSM during updates */
-			heaptup = pg_tde_toast_insert_or_update(relation, newtup, &oldtup, 0);
+			heaptup = pg_tde_toast_insert_or_update(relation, newtup, &oldtup_decrypted, 0);
 			newtupsize = MAXALIGN(heaptup->t_len);
 		}
 		else


### PR DESCRIPTION
pg_tde_toast_insert_or_update calls pg_tde_deform_tuple  on old-tuple from within and tries to dereference the toast columns. Passing the encrypted tuple as part of the old tuple renders the toast data pointer (the encrypted value of the actual pointer) invalid, and anything can happen if it gets dereferenced as it is.
The solution is to pass the decrypted old tuple pg_tde_toast_insert_or_update function from pg_tde_update.